### PR TITLE
Make create task & create event forms functional 

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -9,7 +9,6 @@ permissions:
 
 env:
   NODE_VERSION: 22
-  PNPM_VERSION: 10.15.x
 
 jobs:
   setup-and-deploy:

--- a/app/events/new/page.tsx
+++ b/app/events/new/page.tsx
@@ -30,7 +30,6 @@ export default function NewEventPage() {
 					placeholder="Enter the event title"
 					type="text"
 					required
-					minLength={1}
 				/>
 				{/* <Input name="tags" label="Tags" placeholder="Add a tag" type="text" /> */}
 				{/* <Input name="attendee" label="Attendee" placeholder="Add an attendee" type="text" /> */}

--- a/app/events/new/page.tsx
+++ b/app/events/new/page.tsx
@@ -1,6 +1,6 @@
+import {redirect} from 'next/navigation';
 import CreateForm from '@/components/CreateForm';
 import Input from '@/components/inputs/Input';
-import Select from '@/components/inputs/Select';
 import Textarea from '@/components/inputs/Textarea';
 import api from '@/lib/api';
 import {getWorkspaceId} from '@/lib/util';
@@ -20,8 +20,8 @@ export default function NewEventPage() {
 						start: new Date(formData.get('start') as string),
 						end: new Date(formData.get('end') as string),
 					});
-					// TODO: do something useful
-					console.log(`Created event ${id}`);
+					// TODO: redirect to event page
+					redirect('/');
 				}}
 			>
 				<Input

--- a/app/events/new/page.tsx
+++ b/app/events/new/page.tsx
@@ -1,11 +1,12 @@
 import {redirect} from 'next/navigation';
 import CreateForm from '@/components/CreateForm';
 import Input from '@/components/inputs/Input';
+import TagsInput from '@/components/inputs/TagsInput';
 import Textarea from '@/components/inputs/Textarea';
 import api from '@/lib/api';
 import {getWorkspaceId} from '@/lib/util';
 
-export default function NewEventPage() {
+export default async function NewEventPage() {
 	return (
 		<div className="max-w-3xl mx-auto p-4">
 			<CreateForm
@@ -17,6 +18,7 @@ export default function NewEventPage() {
 						workspaceId: await getWorkspaceId(),
 						title: formData.get('title') as string,
 						description: formData.get('description') as string,
+						tags: formData.getAll('tags') as string[],
 						start: new Date(formData.get('start') as string),
 						end: new Date(formData.get('end') as string),
 					});
@@ -31,7 +33,10 @@ export default function NewEventPage() {
 					type="text"
 					required
 				/>
-				{/* <Input name="tags" label="Tags" placeholder="Add a tag" type="text" /> */}
+				<TagsInput
+					name="tags"
+					options={await api.getTags(await getWorkspaceId())}
+				/>
 				{/* <Input name="attendee" label="Attendee" placeholder="Add an attendee" type="text" /> */}
 				<Input name="start" label="Start date" type="datetime-local" required />
 				<Input name="end" label="End date" type="datetime-local" required />

--- a/app/events/new/page.tsx
+++ b/app/events/new/page.tsx
@@ -20,8 +20,8 @@ export default function NewEventPage() {
 						placeholder: 'Add an attendee',
 						type: 'text',
 					},
-					{name: 'startDate', label: 'Start date', type: 'date'},
-					{name: 'endDate', label: 'End date', type: 'date'},
+					{name: 'startDate', label: 'Start date', type: 'datetime'},
+					{name: 'endDate', label: 'End date', type: 'datetime'},
 					{
 						name: 'description',
 						label: 'Description',

--- a/app/events/new/page.tsx
+++ b/app/events/new/page.tsx
@@ -1,35 +1,47 @@
 import CreateForm from '@/components/CreateForm';
+import Input from '@/components/inputs/Input';
+import Select from '@/components/inputs/Select';
+import Textarea from '@/components/inputs/Textarea';
+import api from '@/lib/api';
+import {getWorkspaceId} from '@/lib/util';
 
 export default function NewEventPage() {
 	return (
 		<div className="max-w-3xl mx-auto p-4">
 			<CreateForm
-				title="Create Event"
+				formTitle="Create Event"
 				submitText="Create Event"
-				fields={[
-					{
-						name: 'eventName',
-						label: 'Event Name',
-						placeholder: 'Enter the event name',
-						type: 'text',
-					},
-					{name: 'tags', label: 'Tags', placeholder: 'Add a tag', type: 'text'},
-					{
-						name: 'attendee',
-						label: 'Attendee',
-						placeholder: 'Add an attendee',
-						type: 'text',
-					},
-					{name: 'startDate', label: 'Start date', type: 'datetime'},
-					{name: 'endDate', label: 'End date', type: 'datetime'},
-					{
-						name: 'description',
-						label: 'Description',
-						placeholder: 'Enter the description',
-						type: 'textarea',
-					},
-				]}
-			/>
+				action={async formData => {
+					'use server';
+					const id = await api.createEvent({
+						workspaceId: await getWorkspaceId(),
+						title: formData.get('title') as string,
+						description: formData.get('description') as string,
+						start: new Date(formData.get('start') as string),
+						end: new Date(formData.get('end') as string),
+					});
+					// TODO: do something useful
+					console.log(`Created event ${id}`);
+				}}
+			>
+				<Input
+					name="title"
+					label="Title"
+					placeholder="Enter the event title"
+					type="text"
+					required
+					minLength={1}
+				/>
+				{/* <Input name="tags" label="Tags" placeholder="Add a tag" type="text" /> */}
+				{/* <Input name="attendee" label="Attendee" placeholder="Add an attendee" type="text" /> */}
+				<Input name="start" label="Start date" type="datetime-local" required />
+				<Input name="end" label="End date" type="datetime-local" required />
+				<Textarea
+					name="description"
+					label="Description"
+					placeholder="Enter the description"
+				/>
+			</CreateForm>
 		</div>
 	);
 }

--- a/app/tasks/new/page.tsx
+++ b/app/tasks/new/page.tsx
@@ -32,7 +32,6 @@ export default function NewTaskPage() {
 					label="Title"
 					placeholder="Enter task title"
 					required
-					minLength={1}
 				/>
 				{/* <Input name="tags" label="Tags" placeholder="Add a tag" type="text" /> */}
 				{/* <Select name="assignee" label="Assign">

--- a/app/tasks/new/page.tsx
+++ b/app/tasks/new/page.tsx
@@ -1,46 +1,61 @@
 import CreateForm from '@/components/CreateForm';
+import Input from '@/components/inputs/Input';
+import Select from '@/components/inputs/Select';
+import Textarea from '@/components/inputs/Textarea';
+import api from '@/lib/api';
+import {Priority} from '@/lib/types';
+import {getWorkspaceId} from '@/lib/util';
 
 export default function NewTaskPage() {
 	return (
 		<div className="max-w-3xl mx-auto p-4">
 			<CreateForm
-				title="Create Task"
+				formTitle="Create Task"
 				submitText="Create Task"
-				fields={[
-					{
-						name: 'taskName',
-						label: 'Task Name',
-						placeholder: 'Enter task name',
-						type: 'text',
-					},
-					{name: 'tags', label: 'Tags', placeholder: 'Add a tag', type: 'text'},
-					{
-						name: 'assignee',
-						label: 'Assign',
-						type: 'select',
-						options: ['User 1', 'User 2'],
-					},
-					{
-						name: 'priority',
-						label: 'Priority',
-						type: 'select',
-						options: ['Low', 'Medium', 'High'],
-					},
-					{name: 'dueDate', label: 'Due date', type: 'datetime'},
-					{
-						name: 'dependency',
-						label: 'Task Dependency',
-						type: 'select',
-						options: ['Task A', 'Task B'],
-					},
-					{
-						name: 'description',
-						label: 'Description',
-						placeholder: 'Enter the description',
-						type: 'textarea',
-					},
-				]}
-			/>
+				action={async formData => {
+					'use server';
+					const deadline = formData.get('deadline') as string;
+					const priority = formData.get('priority') as '' | Priority;
+					const id = await api.createTask({
+						workspaceId: await getWorkspaceId(),
+						title: formData.get('title') as string,
+						description: formData.get('description') as string,
+						...(priority ? {priority} : {}),
+						...(deadline ? {deadline: new Date(deadline as string)} : {}),
+					});
+					// TODO: do something useful
+					console.log(`Created task ${id}`);
+				}}
+			>
+				<Input
+					name="title"
+					label="Title"
+					placeholder="Enter task title"
+					required
+					minLength={1}
+				/>
+				{/* <Input name="tags" label="Tags" placeholder="Add a tag" type="text" /> */}
+				{/* <Select name="assignee" label="Assign">
+					<option>User 1</option>
+					<option>User 2</option>
+				</Select> */}
+				<Select name="priority" label="Priority">
+					<option value="">Select&hellip;</option>
+					<option value={Priority.LOW}>Low</option>
+					<option value={Priority.MEDIUM}>Medium</option>
+					<option value={Priority.HIGH}>High</option>
+				</Select>
+				<Input name="deadline" label="Due date" type="datetime-local" />
+				{/* <Select name="dependency" label="Task Dependency">
+					<option>Task B</option>
+					<option>Task B</option>
+				</Select> */}
+				<Textarea
+					name="description"
+					label="Description"
+					placeholder="Enter the description"
+				/>
+			</CreateForm>
 		</div>
 	);
 }

--- a/app/tasks/new/page.tsx
+++ b/app/tasks/new/page.tsx
@@ -2,12 +2,13 @@ import {redirect} from 'next/navigation';
 import CreateForm from '@/components/CreateForm';
 import Input from '@/components/inputs/Input';
 import Select from '@/components/inputs/Select';
+import TagsInput from '@/components/inputs/TagsInput';
 import Textarea from '@/components/inputs/Textarea';
 import api from '@/lib/api';
 import {Priority} from '@/lib/types';
 import {getWorkspaceId} from '@/lib/util';
 
-export default function NewTaskPage() {
+export default async function NewTaskPage() {
 	return (
 		<div className="max-w-3xl mx-auto p-4">
 			<CreateForm
@@ -21,6 +22,7 @@ export default function NewTaskPage() {
 						workspaceId: await getWorkspaceId(),
 						title: formData.get('title') as string,
 						description: formData.get('description') as string,
+						tags: formData.getAll('tags') as string[],
 						...(priority ? {priority} : {}),
 						...(deadline ? {deadline: new Date(deadline)} : {}),
 					});
@@ -34,7 +36,10 @@ export default function NewTaskPage() {
 					placeholder="Enter task title"
 					required
 				/>
-				{/* <Input name="tags" label="Tags" placeholder="Add a tag" type="text" /> */}
+				<TagsInput
+					name="tags"
+					options={await api.getTags(await getWorkspaceId())}
+				/>
 				{/* <Select name="assignee" label="Assign">
 					<option>User 1</option>
 					<option>User 2</option>

--- a/app/tasks/new/page.tsx
+++ b/app/tasks/new/page.tsx
@@ -26,7 +26,7 @@ export default function NewTaskPage() {
 						type: 'select',
 						options: ['Low', 'Medium', 'High'],
 					},
-					{name: 'dueDate', label: 'Due date', type: 'date'},
+					{name: 'dueDate', label: 'Due date', type: 'datetime'},
 					{
 						name: 'dependency',
 						label: 'Task Dependency',

--- a/app/tasks/new/page.tsx
+++ b/app/tasks/new/page.tsx
@@ -22,7 +22,7 @@ export default function NewTaskPage() {
 						title: formData.get('title') as string,
 						description: formData.get('description') as string,
 						...(priority ? {priority} : {}),
-						...(deadline ? {deadline: new Date(deadline as string)} : {}),
+						...(deadline ? {deadline: new Date(deadline)} : {}),
 					});
 					// TODO: redirect to task page
 					redirect('/');

--- a/app/tasks/new/page.tsx
+++ b/app/tasks/new/page.tsx
@@ -1,3 +1,4 @@
+import {redirect} from 'next/navigation';
 import CreateForm from '@/components/CreateForm';
 import Input from '@/components/inputs/Input';
 import Select from '@/components/inputs/Select';
@@ -23,8 +24,8 @@ export default function NewTaskPage() {
 						...(priority ? {priority} : {}),
 						...(deadline ? {deadline: new Date(deadline as string)} : {}),
 					});
-					// TODO: do something useful
-					console.log(`Created task ${id}`);
+					// TODO: redirect to task page
+					redirect('/');
 				}}
 			>
 				<Input

--- a/components/CreateForm.tsx
+++ b/components/CreateForm.tsx
@@ -1,93 +1,29 @@
-'use client';
-
-
-type FieldProps = {
-	name: string;
-	label: string;
-} & (
-	| {
-			type: 'text' | 'textarea';
-			placeholder: string;
-	  }
-	| {type: 'datetime'}
-	| {
-			type: 'select';
-			options: string[];
-	  }
-);
-
-const Field = (field: FieldProps) => {
-	switch (field.type) {
-		case 'text':
-			return (
-				<input
-					type="text"
-					name={field.name}
-					placeholder={field.placeholder}
-					className="w-full border p-2 rounded"
-				/>
-			);
-
-		case 'datetime':
-			return (
-				<input
-					type="datetime-local"
-					name={field.name}
-					className="w-full border p-2 rounded"
-				/>
-			);
-
-		case 'textarea':
-			return (
-				<textarea
-					name={field.name}
-					placeholder={field.placeholder}
-					className="w-full border p-2 rounded min-h-[100px]"
-				/>
-			);
-
-		case 'select':
-			return (
-				<select name={field.name} className="w-full border p-2 rounded">
-					{field.options.map(opt => (
-						<option key={opt}>{opt}</option>
-					))}
-				</select>
-			);
-	}
-};
-
-interface CreateFormProps {
-	title: string;
-	fields: FieldProps[];
-	submitText?: string;
-}
+import Form from 'next/form';
 
 export default function CreateForm({
-	title,
-	fields,
+	formTitle,
 	submitText = 'Create',
-}: CreateFormProps) {
+	children,
+	...props
+}: React.ComponentPropsWithRef<typeof Form> & {
+	formTitle: string;
+	submitText?: string;
+}) {
 	return (
 		<div className="border border-black rounded-md p-4 space-y-4">
-			<h2 className="text-xl font-bold mb-4">{title}</h2>
+			<h2 className="text-xl font-bold mb-4">{formTitle}</h2>
 
-			{fields.map(field => (
-				<div key={field.name}>
-					<label className="block font-bold mb-1">
-						{field.label}
-						<Field {...field} />
-					</label>
+			<Form {...props}>
+				{children}
+
+				{/* button */}
+				<div className="flex justify-end gap-2 mt-4">
+					<button className="border px-4 py-2 rounded">Cancel</button>
+					<button className="bg-black text-white px-4 py-2 rounded">
+						{submitText}
+					</button>
 				</div>
-			))}
-
-			{/* button */}
-			<div className="flex justify-end gap-2 mt-4">
-				<button className="border px-4 py-2 rounded">Cancel</button>
-				<button className="bg-black text-white px-4 py-2 rounded">
-					{submitText}
-				</button>
-			</div>
+			</Form>
 		</div>
 	);
 }

--- a/components/CreateForm.tsx
+++ b/components/CreateForm.tsx
@@ -13,7 +13,7 @@ export default function CreateForm({
 		<div className="border border-black rounded-md p-4 space-y-4">
 			<h2 className="text-xl font-bold mb-4">{formTitle}</h2>
 
-			<Form {...props}>
+			<Form className="flex flex-col gap-2" {...props}>
 				{children}
 
 				{/* button */}

--- a/components/CreateForm.tsx
+++ b/components/CreateForm.tsx
@@ -9,12 +9,10 @@ type FieldProps = {
 			type: 'text' | 'textarea';
 			placeholder: string;
 	  }
+	| {type: 'date'}
 	| {
 			type: 'select';
 			options: string[];
-	  }
-	| {
-			type: 'date';
 	  }
 );
 
@@ -24,7 +22,17 @@ const Field = (field: FieldProps) => {
 			return (
 				<input
 					type="text"
+					name={field.name}
 					placeholder={field.placeholder}
+					className="w-full border p-2 rounded"
+				/>
+			);
+
+		case 'date':
+			return (
+				<input
+					type="date"
+					name={field.name}
 					className="w-full border p-2 rounded"
 				/>
 			);
@@ -32,6 +40,7 @@ const Field = (field: FieldProps) => {
 		case 'textarea':
 			return (
 				<textarea
+					name={field.name}
 					placeholder={field.placeholder}
 					className="w-full border p-2 rounded min-h-[100px]"
 				/>
@@ -39,15 +48,12 @@ const Field = (field: FieldProps) => {
 
 		case 'select':
 			return (
-				<select className="w-full border p-2 rounded">
+				<select name={field.name} className="w-full border p-2 rounded">
 					{field.options.map(opt => (
 						<option key={opt}>{opt}</option>
 					))}
 				</select>
 			);
-
-		case 'date':
-			return <input type="date" className="w-full border p-2 rounded" />;
 	}
 };
 
@@ -68,8 +74,10 @@ export default function CreateForm({
 
 			{fields.map(field => (
 				<div key={field.name}>
-					<div className="block font-bold mb-1">{field.label}</div>
-					<Field {...field} />
+					<label className="block font-bold mb-1">
+						{field.label}
+						<Field {...field} />
+					</label>
 				</div>
 			))}
 

--- a/components/CreateForm.tsx
+++ b/components/CreateForm.tsx
@@ -9,7 +9,7 @@ type FieldProps = {
 			type: 'text' | 'textarea';
 			placeholder: string;
 	  }
-	| {type: 'date'}
+	| {type: 'datetime'}
 	| {
 			type: 'select';
 			options: string[];
@@ -28,10 +28,10 @@ const Field = (field: FieldProps) => {
 				/>
 			);
 
-		case 'date':
+		case 'datetime':
 			return (
 				<input
-					type="date"
+					type="datetime-local"
 					name={field.name}
 					className="w-full border p-2 rounded"
 				/>

--- a/components/CreateForm.tsx
+++ b/components/CreateForm.tsx
@@ -1,18 +1,59 @@
 'use client';
 
-type FieldType = 'text' | 'textarea' | 'select' | 'date';
 
-interface FieldConfig {
+type FieldProps = {
 	name: string;
 	label: string;
-	placeholder?: string;
-	type: FieldType;
-	options?: string[];
-}
+} & (
+	| {
+			type: 'text' | 'textarea';
+			placeholder: string;
+	  }
+	| {
+			type: 'select';
+			options: string[];
+	  }
+	| {
+			type: 'date';
+	  }
+);
+
+const Field = (field: FieldProps) => {
+	switch (field.type) {
+		case 'text':
+			return (
+				<input
+					type="text"
+					placeholder={field.placeholder}
+					className="w-full border p-2 rounded"
+				/>
+			);
+
+		case 'textarea':
+			return (
+				<textarea
+					placeholder={field.placeholder}
+					className="w-full border p-2 rounded min-h-[100px]"
+				/>
+			);
+
+		case 'select':
+			return (
+				<select className="w-full border p-2 rounded">
+					{field.options.map(opt => (
+						<option key={opt}>{opt}</option>
+					))}
+				</select>
+			);
+
+		case 'date':
+			return <input type="date" className="w-full border p-2 rounded" />;
+	}
+};
 
 interface CreateFormProps {
 	title: string;
-	fields: FieldConfig[];
+	fields: FieldProps[];
 	submitText?: string;
 }
 
@@ -28,33 +69,7 @@ export default function CreateForm({
 			{fields.map(field => (
 				<div key={field.name}>
 					<div className="block font-bold mb-1">{field.label}</div>
-
-					{field.type === 'text' && (
-						<input
-							type="text"
-							placeholder={field.placeholder}
-							className="w-full border p-2 rounded"
-						/>
-					)}
-
-					{field.type === 'textarea' && (
-						<textarea
-							placeholder={field.placeholder}
-							className="w-full border p-2 rounded min-h-[100px]"
-						/>
-					)}
-
-					{field.type === 'select' && (
-						<select className="w-full border p-2 rounded">
-							{field.options?.map(opt => (
-								<option key={opt}>{opt}</option>
-							))}
-						</select>
-					)}
-
-					{field.type === 'date' && (
-						<input type="date" className="w-full border p-2 rounded" />
-					)}
+					<Field {...field} />
 				</div>
 			))}
 

--- a/components/Task.tsx
+++ b/components/Task.tsx
@@ -16,7 +16,11 @@ export const exampleTask: NonNullable<TaskWithAssigneesAndTags> = {
 		{name: 'John Doe', id: '0', email: 'jdoe@mail.com'},
 		{name: 'Jane Smith', id: '1', email: 'jsmith@mail.com'},
 	],
-	tags: [{name: 'report'}, {name: 'project'}, {name: 'deadline'}],
+	tags: [
+		{name: 'report', id: '1', workspaceId: 'workspace-123'},
+		{name: 'project', id: '2', workspaceId: 'workspace-123'},
+		{name: 'deadline', id: '3', workspaceId: 'workspace-123'},
+	],
 };
 
 const LeftRightLabelContents = ({

--- a/components/inputs/Input.tsx
+++ b/components/inputs/Input.tsx
@@ -1,0 +1,11 @@
+export default function Input({
+	label,
+	...props
+}: React.ComponentPropsWithRef<'input'> & {label: string}) {
+	return (
+		<label>
+			{label}
+			<input className="w-full border p-2 rounded" {...props} />
+		</label>
+	);
+}

--- a/components/inputs/Select.tsx
+++ b/components/inputs/Select.tsx
@@ -1,0 +1,13 @@
+export default function Input({
+	label,
+	...props
+}: React.ComponentPropsWithRef<'select'> & {label: string}) {
+	return (
+		<label>
+			{label}
+			<select className="w-full border p-2 rounded" {...props}>
+				{props.children}
+			</select>
+		</label>
+	);
+}

--- a/components/inputs/TagsInput.tsx
+++ b/components/inputs/TagsInput.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import {useId, useState} from 'react';
+
+export default function TagsInput({
+	name,
+	options,
+	label = 'Tags',
+	placeholder = 'Add a tag',
+	...props
+}: React.ComponentPropsWithRef<'input'> & {
+	label?: string;
+	options: string[];
+}) {
+	const id = useId();
+	const [selected, setSelected] = useState<readonly string[]>([]);
+	return (
+		<label>
+			{label}
+			<div className="flex gap-2">
+				{selected.map(item => (
+					<span
+						key={item}
+						className="mt-2 mb-2 flex gap-2 rounded bg-gray-200 text-gray-700 text-sm font-semibold px-3 py-1"
+					>
+						<input type="hidden" name={name} value={item} />
+						{item}
+						<button
+							type="button"
+							onClick={() => setSelected(selected.filter(t => t !== item))}
+							className="text-gray-500 hover:text-gray-700"
+						>
+							&times;
+						</button>
+					</span>
+				))}
+			</div>
+			<input
+				type="text"
+				list={id}
+				className="w-full border p-2 rounded"
+				placeholder={placeholder}
+				onKeyDown={e => {
+					if (e.key === 'Enter' && e.currentTarget.value) {
+						e.preventDefault();
+						setSelected([...selected, e.currentTarget.value]);
+						e.currentTarget.value = '';
+					}
+				}}
+				{...props}
+			/>
+			<datalist id={id}>
+				{options
+					.filter(option => !selected.includes(option))
+					.map(option => (
+						<option key={option} value={option}>
+							{option}
+						</option>
+					))}
+			</datalist>
+		</label>
+	);
+}

--- a/components/inputs/Textarea.tsx
+++ b/components/inputs/Textarea.tsx
@@ -1,0 +1,14 @@
+export default function Input({
+	label,
+	...props
+}: React.ComponentPropsWithRef<'textarea'> & {label: string}) {
+	return (
+		<label>
+			{label}
+			<textarea
+				className="w-full border p-2 rounded min-h-[100px]"
+				{...props}
+			/>
+		</label>
+	);
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -275,6 +275,16 @@ export const createAPI = (prisma: PrismaClient) => {
 				orderBy: [{start: 'asc'}, {end: 'asc'}],
 			}),
 
+		/** Sorted in ascending order */
+		getTags: async (workspaceId: Id) =>
+			(
+				await prisma.tag.findMany({
+					where: {workspaceId},
+					select: {name: true},
+					orderBy: {name: 'asc'},
+				})
+			).map(t => t.name),
+
 		createTask: async ({
 			workspaceId,
 			tags = [],
@@ -302,8 +312,8 @@ export const createAPI = (prisma: PrismaClient) => {
 						workspace: {connect: {id: workspaceId}},
 						tags: {
 							connectOrCreate: tags.map(name => ({
-								where: {name},
-								create: {name},
+								where: {workspaceId_name: {workspaceId, name}},
+								create: {workspaceId, name},
 							})),
 						},
 						assignees: {connect: assignees.map(id => ({id}))},
@@ -347,7 +357,11 @@ export const createAPI = (prisma: PrismaClient) => {
 					select: {id: true},
 					where: {id},
 					data: {
-						tags: {set: tags?.map(name => ({name})) ?? Prisma.skip},
+						tags: {
+							set:
+								tags?.map(name => ({workspaceId_name: {workspaceId, name}})) ??
+								Prisma.skip,
+						},
 						assignees: {connect: assignees?.map(id => ({id})) ?? Prisma.skip},
 						dependencies: {
 							connect: dependencies?.map(id => ({id})) ?? Prisma.skip,
@@ -370,7 +384,12 @@ export const createAPI = (prisma: PrismaClient) => {
 				select: {id: true},
 				data: {
 					workspace: {connect: {id: workspaceId}},
-					tags: {create: tags.map(name => ({name}))},
+					tags: {
+						connectOrCreate: tags.map(name => ({
+							where: {workspaceId_name: {workspaceId, name}},
+							create: {workspaceId, name},
+						})),
+					},
 					attendees: {connect: attendees.map(id => ({id}))},
 					...rest,
 				},
@@ -381,18 +400,27 @@ export const createAPI = (prisma: PrismaClient) => {
 		updateEvent: async (
 			id: Id,
 			{tags, attendees, ...rest}: Partial<Omit<CreateEventArgs, 'workspaceId'>>,
-		): Promise<void> => {
-			// TODO: check attendees have access to event
-			await prisma.event.update({
-				select: {id: true},
-				where: {id},
-				data: {
-					tags: {set: tags?.map(name => ({name})) ?? Prisma.skip},
-					attendees: {connect: attendees?.map(id => ({id})) ?? Prisma.skip},
-					...rest,
-				},
-			});
-		},
+		): Promise<void> =>
+			prisma.$transaction(async prisma => {
+				// TODO: check attendees have access to event
+				const {workspaceId} = await prisma.task.findUniqueOrThrow({
+					select: {workspaceId: true},
+					where: {id},
+				});
+				await prisma.event.update({
+					select: {id: true},
+					where: {id},
+					data: {
+						tags: {
+							set:
+								tags?.map(name => ({workspaceId_name: {workspaceId, name}})) ??
+								Prisma.skip,
+						},
+						attendees: {connect: attendees?.map(id => ({id})) ?? Prisma.skip},
+						...rest,
+					},
+				});
+			}),
 
 		// #endregion
 	};

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -138,12 +138,14 @@ export const createAPI = (prisma: PrismaClient) => {
 	const checkTask = async (
 		prisma: TransactionClient,
 		{
+			title,
 			workspaceId,
 			visibility,
 			assignees,
 			dependencies,
 			parents,
 		}: {
+			title: string;
 			workspaceId: Id;
 			visibility: WorkspaceMemberRole;
 			assignees?: Id[] | undefined;
@@ -153,6 +155,7 @@ export const createAPI = (prisma: PrismaClient) => {
 	): Promise<Error[]> =>
 		(
 			await Promise.all([
+				...(!title ? [new Error('Title must not be empty')] : []),
 				...(assignees
 					? [
 							checkWorkspaceMembers(
@@ -277,10 +280,12 @@ export const createAPI = (prisma: PrismaClient) => {
 			dependencies = [],
 			parents = [],
 			visibility = 'MEMBER',
+			title,
 			...rest
 		}: CreateTaskArgs): Promise<Id> =>
 			prisma.$transaction(async prisma => {
 				const errors = await checkTask(prisma, {
+					title,
 					workspaceId,
 					visibility,
 					assignees,
@@ -303,6 +308,7 @@ export const createAPI = (prisma: PrismaClient) => {
 						dependencies: {connect: dependencies.map(id => ({id}))},
 						parents: {connect: parents.map(id => ({id}))},
 						visibility,
+						title,
 						...rest,
 					},
 				});

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -145,7 +145,7 @@ export const createAPI = (prisma: PrismaClient) => {
 			dependencies,
 			parents,
 		}: {
-			title: string;
+			title?: string | undefined;
 			workspaceId: Id;
 			visibility: WorkspaceMemberRole;
 			assignees?: Id[] | undefined;
@@ -155,7 +155,9 @@ export const createAPI = (prisma: PrismaClient) => {
 	): Promise<Error[]> =>
 		(
 			await Promise.all([
-				...(!title ? [new Error('Title must not be empty')] : []),
+				...(title !== undefined && !title
+					? [new Error('Title must not be empty')]
+					: []),
 				...(assignees
 					? [
 							checkWorkspaceMembers(
@@ -322,6 +324,7 @@ export const createAPI = (prisma: PrismaClient) => {
 				assignees,
 				dependencies,
 				parents,
+				title,
 				...rest
 			}: Partial<Omit<CreateTaskArgs, 'workspaceId'>>,
 		): Promise<void> =>
@@ -331,6 +334,7 @@ export const createAPI = (prisma: PrismaClient) => {
 					where: {id},
 				});
 				const errors = await checkTask(prisma, {
+					title,
 					workspaceId,
 					visibility,
 					assignees,
@@ -349,6 +353,7 @@ export const createAPI = (prisma: PrismaClient) => {
 							connect: dependencies?.map(id => ({id})) ?? Prisma.skip,
 						},
 						parents: {connect: parents?.map(id => ({id})) ?? Prisma.skip},
+						...(title !== undefined ? {title} : {}),
 						...rest,
 					},
 				});

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,17 +1,17 @@
 import type api from '@/lib/api';
 import type {WorkspaceMemberRole} from './generated/prisma';
 
-export type {
-	Event,
+export {
 	Priority,
-	Task,
-	Tag,
 	TaskStatus,
-	User,
-	Workspace,
-	WorkspaceInvite,
-	WorkspaceMember,
 	WorkspaceMemberRole,
+	type Event,
+	type Task,
+	type Tag,
+	type User,
+	type Workspace,
+	type WorkspaceInvite,
+	type WorkspaceMember,
 } from './generated/prisma';
 
 export type Id = string;

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,0 +1,7 @@
+// TODO: remove once workspaces are implemented
+
+import prisma from './prisma';
+import type {Id} from './types';
+
+export const getWorkspaceId = async (): Promise<Id> =>
+	(await prisma.workspace.findFirstOrThrow({select: {id: true}})).id;

--- a/prisma/migrations/20250824053001_tags_per_workspace/migration.sql
+++ b/prisma/migrations/20250824053001_tags_per_workspace/migration.sql
@@ -1,0 +1,32 @@
+/*
+  Warnings:
+
+  - The primary key for the `Tag` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - A unique constraint covering the columns `[workspaceId,name]` on the table `Tag` will be added. If there are existing duplicate values, this will fail.
+  - The required column `id` was added to the `Tag` table with a prisma-level default value. This is not possible if the table is not empty. Please add this column as optional, then populate it before making it required.
+  - Added the required column `workspaceId` to the `Tag` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."_EventToTag" DROP CONSTRAINT "_EventToTag_B_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."_TagToTask" DROP CONSTRAINT "_TagToTask_A_fkey";
+
+-- AlterTable
+ALTER TABLE "public"."Tag" DROP CONSTRAINT "Tag_pkey",
+ADD COLUMN     "id" TEXT NOT NULL,
+ADD COLUMN     "workspaceId" TEXT NOT NULL,
+ADD CONSTRAINT "Tag_pkey" PRIMARY KEY ("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Tag_workspaceId_name_key" ON "public"."Tag"("workspaceId", "name");
+
+-- AddForeignKey
+ALTER TABLE "public"."Tag" ADD CONSTRAINT "Tag_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "public"."Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."_EventToTag" ADD CONSTRAINT "_EventToTag_B_fkey" FOREIGN KEY ("B") REFERENCES "public"."Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."_TagToTask" ADD CONSTRAINT "_TagToTask_A_fkey" FOREIGN KEY ("A") REFERENCES "public"."Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,9 +64,14 @@ model Event {
 }
 
 model Tag {
-  name   String  @id
-  tasks  Task[]
-  events Event[]
+  id          String    @id @default(cuid(2))
+  workspaceId String
+  name        String
+  tasks       Task[]
+  events      Event[]
+  Workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+
+  @@unique([workspaceId, name])
 }
 
 model Workspace {
@@ -79,6 +84,7 @@ model Workspace {
 
   tasks   Task[]
   events  Event[]
+  tags    Tag[]
   invites WorkspaceInvite[]
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,7 @@ generator client {
   provider        = "prisma-client-js"
   output          = "../lib/generated/prisma"
   previewFeatures = ["strictUndefinedChecks"]
+  binaryTargets   = ["native", "rhel-openssl-3.0.x"]
 }
 
 model User {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,5 @@
-import type {PrismaClient} from '@/lib/generated/prisma';
+import type {Id} from '@/lib/types';
+import type {PrismaClient} from '@/lib/prisma';
 
 export default async (prisma: PrismaClient): Promise<void> => {
 	const {id: alice} = await prisma.user.create({
@@ -31,11 +32,20 @@ export default async (prisma: PrismaClient): Promise<void> => {
 		select: {id: true},
 	});
 
+	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+	const tags = (...tags: readonly string[]) => ({
+		connectOrCreate: tags.map(name => ({
+			where: {workspaceId_name: {workspaceId, name}},
+			create: {workspaceId, name},
+		})),
+	});
+
 	await prisma.task.create({
 		data: {
 			workspaceId,
 			title: 'Alice Task 1',
 			deadline: new Date('2025-08-24'),
+			tags: tags('tag1', 'tag2'),
 			assignees: {connect: {id: alice}},
 		},
 	});
@@ -44,6 +54,7 @@ export default async (prisma: PrismaClient): Promise<void> => {
 			workspaceId,
 			title: 'Alice Task 2',
 			deadline: new Date('2025-08-31'),
+			tags: tags('tag2', 'tag3'),
 			assignees: {connect: {id: alice}},
 		},
 	});

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,1 +1,5 @@
 @import 'tailwindcss';
+
+button {
+	cursor: pointer;
+}


### PR DESCRIPTION
- The create task & create event forms are functional now
  - Adds it to the first workspace in the database for now - must run `pnpm db:seed` to seed the database if running the database locally
  - Deadline/start/end dates are now date **and time** pickers
  - Added `cursor: pointer` style to buttons
- Backend now checks that task title is nonempty
- Tags, assignees, attendees, and dependencies input are commented out for now - will do in a later PR